### PR TITLE
fix: resolve compile error + add withdraw function

### DIFF
--- a/clarity/contracts/sbtc-vault.clar
+++ b/clarity/contracts/sbtc-vault.clar
@@ -39,7 +39,7 @@
 
     ;; Transfer sBTC from user to contract
     ;; Note: contract-call? requires literal contract identifier, not a constant
-    (try! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer amount tx-sender current-contract none))
+    (try! (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer amount tx-sender (as-contract tx-sender) none))
 
     ;; Update user's deposit balance
     (map-set deposits tx-sender (+ (get-balance tx-sender) amount))
@@ -49,6 +49,28 @@
 
     ;; Update total deposits
     (var-set total-deposits (+ (var-get total-deposits) amount))
+
+    (ok amount)
+  )
+)
+
+(define-public (withdraw (amount uint) (recipient principal))
+  (begin
+    ;; Only contract owner can withdraw
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    (asserts! (> amount u0) err-zero-amount)
+
+    ;; Ensure recipient has sufficient vault balance
+    (asserts! (>= (get-balance recipient) amount) err-insufficient-balance)
+
+    ;; Transfer sBTC from contract to recipient
+    (try! (as-contract (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token transfer amount tx-sender recipient none)))
+
+    ;; Update recipient's deposit balance
+    (map-set deposits recipient (- (get-balance recipient) amount))
+
+    ;; Update total deposits
+    (var-set total-deposits (- (var-get total-deposits) amount))
 
     (ok amount)
   )


### PR DESCRIPTION
## Summary

- **Fix invalid Clarity syntax**: Replace `current-contract` (which does not exist in Clarity) with `(as-contract tx-sender)` in the `deposit` function. This resolves the compile error that prevents the contract from deploying.
- **Add `withdraw` function**: New owner-only public function that allows the contract deployer to withdraw sBTC on behalf of a depositor. Includes guards for zero-amount, insufficient balance, and owner-only access (`err u100`, `err u101`, `err u102`). Updates both the per-user deposit map and `total-deposits` variable to keep accounting consistent.

Closes #2

## Changes

**`clarity/contracts/sbtc-vault.clar`**

1. `deposit` function (line 42): `current-contract` -> `(as-contract tx-sender)`
2. New `withdraw` function:
   - `(withdraw (amount uint) (recipient principal))` -> `(response uint uint)`
   - Owner-only: `(asserts! (is-eq tx-sender contract-owner) err-owner-only)`
   - Validates amount > 0 and recipient has sufficient vault balance
   - Uses `(as-contract ...)` to transfer sBTC from the contract back to recipient
   - Decrements the recipient's deposit balance and total-deposits

## Test plan

- [ ] Verify contract compiles with `clarinet check`
- [ ] Test deposit still works correctly after the `(as-contract tx-sender)` fix
- [ ] Test withdraw succeeds when called by contract owner
- [ ] Test withdraw fails with `err u100` when called by non-owner
- [ ] Test withdraw fails with `err u102` when amount is zero
- [ ] Test withdraw fails with `err u101` when amount exceeds recipient's vault balance
- [ ] Test that total-deposits and per-user balance are correctly decremented after withdraw

🤖 Generated with [Claude Code](https://claude.com/claude-code)